### PR TITLE
Add note to README about new dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ A major source of guidance and reference in structuring and populating this meta
 ## Background reading
 1. [Cross-Domain Interoperability Framework (CDIF)](https://worldfair-project.eu/cross-domain-interoperability-framework/ )
 2. [JSON-LD Best Practices](https://w3c.github.io/json-ld-bp/ )
+
+
+## Dependencies
+
+The public website deployed by this project depends on the assets made public by PSDI's "css-template" at https://psdi-uk.github.io/css-template/. Any changes to these assets will be reflected in this project's website, and this project should ideally be tested with any changes before they're made live. An issue with retrieving these assets will appear as the website appear unstyled and missing its header and footer.
+
+In case these assets become no longer available for some reason, the commit `517e74b99fba4920c4eea4b17131fdd42eb93f72` can be used as a reference to restore local versions of them.


### PR DESCRIPTION
I just realized it's probably a good idea to note now in the README that this now depends on the public assets of the css-template project. This also notes the last commit prior to them being used, so it can be referenced in case those changes need to be reverted in the future.