### PR TITLE
Improve formatting for pre block

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       <p>Guidance about the PSDI metadata can be found at <a href="https://psdi-uk.github.io/docusaurus-pages/docs/category/psdi-metadata">PSDI metadata guidance in the PSDI knowledgebase</a>.</p>
 	    <p>The metadata is made available in <a href="https://json-ld.org/">JSON-LD format</a> (.jsonld files) and equivalent <a href="https://www.w3.org/TR/turtle/">Terse RDF Triple Language</a> (.ttl files).</p>
       <p>Metadata available is shown below:</p>
-      <pre>
+      <pre style="white-space: pre-wrap;">
         https://psdi-uk.github.io/metadata/
         ├── <a href="./vocabulary.jsonld">vocabulary.jsonld</a> (SKOS vocabulary definining nomenclature used within the PSDI project and the resulting PSDI infrastructure and its platform)
         ├── <a href="./resource-catalogue.jsonld">resource-catalogue.jsonld</a> ( DCAT description of catalogue of resources (data, services, tools and guidance) made available via PSDI)


### PR DESCRIPTION
Hi Aileen. As you suspect, it's the `pre` block which is causing trouble for the page. Let me explain what's going on:

`pre` is used for pre-formatted text, which means you're telling the browser you don't want any additional formatting to apply to - even wrapping long lines of text, unless you specify otherwise. Since this block does have long lines of text, they don't get wrapped no matter how narrow the screen is. The browser tries its best to centre it on-screen, which results in the far left and right sides being cut off.

How to fix it? That depends on what you want to. The simplest solution (which is what I've implemented here) is to use one of the very few styling options allowed for `pre` blocks to tell it to wrap long lines. The wrap doesn't align well with the manual indents, but it at least prevents the block from overloading the page.

One alternative is that you could manually wrap the text at a width you'd like. This will look fine if the browser is wide enough, but will still run into a problem if the browser is narrower than and will have to wrap anyway. And if you make it too narrow, it will appear too thin on wide browsers.

The best formatting would be achieved by doing this nested list directly in HTML (you can use a Markdown-to-HTML converter to help, or I can show you how to do it if you'd prefer), and the lines of it can be `pre` blocks (with wrapping enabled) if you want.

Let me know what you'd like to go ahead with, and I'll help out. I can also show you some ways to see how the site will look live before deploying it, if you want to be able to test changes first without risking a broken change going live.