### PR TITLE
Update to use new source of common style assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Please see:
 
 ## Dependencies
 
-The public website deployed by this project depends on the assets made public by PSDI's "css-template" at https://psdi-uk.github.io/css-template/. Any changes to these assets will be reflected in this project's website, and this project should ideally be tested with any changes before they're made live. An issue with retrieving these assets will appear as the website appear unstyled and missing its header and footer.
+The public website deployed by this project depends on the assets made public by PSDI's common style project at https://github.com/PSDI-UK/psdi-common-style. Any changes to these assets will be reflected in this project's website, and this project should ideally be tested with any changes before they're made live. An issue with retrieving these assets will appear as the website appear unstyled and missing its header and footer.
 
 In case these assets become no longer available for some reason, the commit `517e74b99fba4920c4eea4b17131fdd42eb93f72` can be used as a reference to restore local versions of them.

--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
   <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:700" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Lexend:400" rel="stylesheet" type="text/css">
-  <link rel="stylesheet" href="https://psdi-uk.github.io/css-template/psdi-common.css">
+  <link rel="stylesheet" href="https://psdi-uk.github.io/psdi-common-style/css/psdi-common.css">
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.3/jquery.min.js"></script>
-  <script src="https://psdi-uk.github.io/css-template/psdi-common.js" type="module"></script>
+  <script src="https://psdi-uk.github.io/psdi-common-style/js/psdi-common.js" type="module"></script>
   <title>PSDI metadata</title>
 </head>
 
@@ -31,7 +31,7 @@
   <header class="header" id="psdi-header"></header>
 
   <script type="module">
-    import { setTitle, setHeaderLinksSource } from "https://psdi-uk.github.io/css-template/psdi-common.js";
+    import { setTitle, setHeaderLinksSource } from "https://psdi-uk.github.io/psdi-common-style/js/psdi-common.js";
     setTitle("Metadata");
     setHeaderLinksSource("index_files/header-links.html");
   </script>


### PR DESCRIPTION
The source of the assets is being migrated from the "css-template" project to the more-fittingly-named "psdi-common-style" project, so this updates all links to point to the new project